### PR TITLE
Make sure issues with a milestone aren't labeled

### DIFF
--- a/bin/mark_stale_issues
+++ b/bin/mark_stale_issues
@@ -12,7 +12,7 @@ client = Octokit::Client.new(:netrc => true)
 client.auto_paginate = true
 issues = client.issues 'rails/rails', state: :open, sort: :updated, direction: :asc
 old_issues = issues.select do |issue|
-  (issue.updated_at < 3.months.ago) && !issue.pull_request.rels[:self]
+  (issue.updated_at < 3.months.ago) && !issue.pull_request.rels[:self] && issue.milestone
 end
 
 message = <<-BODY


### PR DESCRIPTION
Hello,

This is just a tiny pull request that makes sure that if an issue is under a milestone, it is not labeled as "stale" since point versions are released every six months.

Have a nice day.
